### PR TITLE
[Step02_Step1 과제 리펙터링] 응답값 DTO 변경, CustomException 추가

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
+++ b/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
@@ -26,6 +26,7 @@ class ApiControllerAdvice : ResponseEntityExceptionHandler() {
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
         logger.error(e.message)
+
         val statusCode = HttpStatus.BAD_REQUEST.value()
         return ResponseEntity(
             ErrorResponse(statusCode.toString(), e.message.toString()),

--- a/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
+++ b/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
@@ -25,8 +25,13 @@ class ApiControllerAdvice : ResponseEntityExceptionHandler() {
         )
     }
 
-    @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+    @ExceptionHandler(value = [
+        IllegalArgumentException::class,
+        NotEnoughPointsException::class,
+        InvalidPointAmountException::class,
+        InvalidAmountRequestException::class
+    ])
+    fun handleCommonExceptions(e: Exception): ResponseEntity<ErrorResponse> {
         logger.error(e.message)
 
         val statusCode = HttpStatus.BAD_REQUEST.value()
@@ -35,39 +40,5 @@ class ApiControllerAdvice : ResponseEntityExceptionHandler() {
             HttpStatus.BAD_REQUEST,
         )
     }
-
-    @ExceptionHandler(NotEnoughPointsException::class)
-    fun handleNotEnoughPointsExceptionException(e: NotEnoughPointsException): ResponseEntity<ErrorResponse> {
-        logger.error(e.message)
-
-        val statusCode = HttpStatus.BAD_REQUEST.value()
-        return ResponseEntity(
-            ErrorResponse(statusCode.toString(), e.message.toString()),
-            HttpStatus.BAD_REQUEST,
-        )
-    }
-
-    @ExceptionHandler(InvalidPointAmountException::class)
-    fun handleNotEnoughPointsExceptionException(e: InvalidPointAmountException): ResponseEntity<ErrorResponse> {
-        logger.error(e.message)
-
-        val statusCode = HttpStatus.BAD_REQUEST.value()
-        return ResponseEntity(
-            ErrorResponse(statusCode.toString(), e.message.toString()),
-            HttpStatus.BAD_REQUEST,
-        )
-    }
-
-    @ExceptionHandler(InvalidAmountRequestException::class)
-    fun handleNotEnoughPointsExceptionException(e: InvalidAmountRequestException): ResponseEntity<ErrorResponse> {
-        logger.error(e.message)
-
-        val statusCode = HttpStatus.BAD_REQUEST.value()
-        return ResponseEntity(
-            ErrorResponse(statusCode.toString(), e.message.toString()),
-            HttpStatus.BAD_REQUEST,
-        )
-    }
-
 
 }

--- a/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
+++ b/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd
 
+import io.hhplus.tdd.exception.InvalidAmountRequestException
 import io.hhplus.tdd.exception.InvalidPointAmountException
 import io.hhplus.tdd.exception.NotEnoughPointsException
 import org.slf4j.Logger
@@ -48,6 +49,17 @@ class ApiControllerAdvice : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(InvalidPointAmountException::class)
     fun handleNotEnoughPointsExceptionException(e: InvalidPointAmountException): ResponseEntity<ErrorResponse> {
+        logger.error(e.message)
+
+        val statusCode = HttpStatus.BAD_REQUEST.value()
+        return ResponseEntity(
+            ErrorResponse(statusCode.toString(), e.message.toString()),
+            HttpStatus.BAD_REQUEST,
+        )
+    }
+
+    @ExceptionHandler(InvalidAmountRequestException::class)
+    fun handleNotEnoughPointsExceptionException(e: InvalidAmountRequestException): ResponseEntity<ErrorResponse> {
         logger.error(e.message)
 
         val statusCode = HttpStatus.BAD_REQUEST.value()

--- a/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
+++ b/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd
 
+import io.hhplus.tdd.exception.NotEnoughPointsException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -7,7 +8,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
-import kotlin.math.log
 
 data class ErrorResponse(val code: String, val message: String)
 
@@ -25,6 +25,17 @@ class ApiControllerAdvice : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+        logger.error(e.message)
+
+        val statusCode = HttpStatus.BAD_REQUEST.value()
+        return ResponseEntity(
+            ErrorResponse(statusCode.toString(), e.message.toString()),
+            HttpStatus.BAD_REQUEST,
+        )
+    }
+
+    @ExceptionHandler(NotEnoughPointsException::class)
+    fun handleNotEnoughPointsExceptionException(e: NotEnoughPointsException): ResponseEntity<ErrorResponse> {
         logger.error(e.message)
 
         val statusCode = HttpStatus.BAD_REQUEST.value()

--- a/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
+++ b/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd
 
+import io.hhplus.tdd.exception.InvalidPointAmountException
 import io.hhplus.tdd.exception.NotEnoughPointsException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -36,6 +37,17 @@ class ApiControllerAdvice : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(NotEnoughPointsException::class)
     fun handleNotEnoughPointsExceptionException(e: NotEnoughPointsException): ResponseEntity<ErrorResponse> {
+        logger.error(e.message)
+
+        val statusCode = HttpStatus.BAD_REQUEST.value()
+        return ResponseEntity(
+            ErrorResponse(statusCode.toString(), e.message.toString()),
+            HttpStatus.BAD_REQUEST,
+        )
+    }
+
+    @ExceptionHandler(InvalidPointAmountException::class)
+    fun handleNotEnoughPointsExceptionException(e: InvalidPointAmountException): ResponseEntity<ErrorResponse> {
         logger.error(e.message)
 
         val statusCode = HttpStatus.BAD_REQUEST.value()

--- a/src/main/kotlin/io/hhplus/tdd/exception/InvalidAmountRequestException.kt
+++ b/src/main/kotlin/io/hhplus/tdd/exception/InvalidAmountRequestException.kt
@@ -1,0 +1,4 @@
+package io.hhplus.tdd.exception
+
+class InvalidAmountRequestException(message: String) : Exception(message) {
+}

--- a/src/main/kotlin/io/hhplus/tdd/exception/InvalidPointAmountException.kt
+++ b/src/main/kotlin/io/hhplus/tdd/exception/InvalidPointAmountException.kt
@@ -1,0 +1,4 @@
+package io.hhplus.tdd.exception
+
+class InvalidPointAmountException(message: String?) : RuntimeException(message)  {
+}

--- a/src/main/kotlin/io/hhplus/tdd/exception/NotEnoughPointsException.kt
+++ b/src/main/kotlin/io/hhplus/tdd/exception/NotEnoughPointsException.kt
@@ -1,0 +1,4 @@
+package io.hhplus.tdd.exception
+
+class NotEnoughPointsException(message: String?) : RuntimeException(message) {
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/controller/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/controller/PointController.kt
@@ -1,17 +1,22 @@
 package io.hhplus.tdd.point.controller
 
-import io.hhplus.tdd.point.domain.PointHistory
 import io.hhplus.tdd.point.domain.PointHistoryService
-import io.hhplus.tdd.point.domain.UserPoint
 import io.hhplus.tdd.point.domain.UserPointService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/point")
-class PointController(private val userPointService: UserPointService,
-                      private val pointHistoryService: PointHistoryService) {
+class PointController(
+    private val userPointService: UserPointService,
+    private val pointHistoryService: PointHistoryService
+) {
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     /**
@@ -20,9 +25,9 @@ class PointController(private val userPointService: UserPointService,
     @GetMapping("{id}")
     fun point(
         @PathVariable id: Long,
-    ): UserPoint {
+    ): PointDto.UserPointResponse {
         logger.info("Get point by id: $id")
-        return userPointService.getUserPointById(id)
+        return PointDto.UserPointResponse(userPointService.getUserPointById(id))
     }
 
     /**
@@ -31,9 +36,10 @@ class PointController(private val userPointService: UserPointService,
     @GetMapping("{id}/histories")
     fun history(
         @PathVariable id: Long,
-    ): List<PointHistory> {
+    ): List<PointDto.UserPointHistoryResponse> {
         logger.info("Get point List by userId: $id")
         return pointHistoryService.getAllByUserId(id)
+            .map { PointDto.UserPointHistoryResponse(it) }
     }
 
     /**
@@ -43,15 +49,15 @@ class PointController(private val userPointService: UserPointService,
     fun charge(
         @PathVariable id: Long,
         @RequestBody amount: Long
-    ): UserPoint {
+    ): PointDto.UserPointResponse {
         logger.info("포인트 업데이트 id : $id, amount : $amount")
 
-        if(amount < 0) {
+        if (amount < 0) {
             val message = "충전 금액은 최소 1원 이상 부터 가능합니다. 현재 충전 요청 금액 : $amount"
             throw IllegalArgumentException(message)
         }
 
-        return userPointService.chargeUserPoint(id, amount)
+        return PointDto.UserPointResponse(userPointService.chargeUserPoint(id, amount))
     }
 
     /**
@@ -61,14 +67,14 @@ class PointController(private val userPointService: UserPointService,
     fun use(
         @PathVariable id: Long,
         @RequestBody amount: Long,
-    ): UserPoint {
+    ): PointDto.UserPointResponse {
         logger.info("포인트 사용 id : $id, amount : $amount")
 
-        if(amount < 0) {
+        if (amount < 0) {
             val message = "사용 금액은 최소 0원 이상 부터 가능합니다. 현재 사용 요청 금액 : $amount"
             throw IllegalArgumentException(message)
         }
 
-        return userPointService.useUserPoint(id, amount);
+        return PointDto.UserPointResponse(userPointService.useUserPoint(id, amount))
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/controller/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/controller/PointController.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point.controller
 
+import io.hhplus.tdd.exception.InvalidAmountRequestException
 import io.hhplus.tdd.point.domain.PointHistoryService
 import io.hhplus.tdd.point.domain.UserPointService
 import org.slf4j.Logger
@@ -52,9 +53,9 @@ class PointController(
     ): PointDto.UserPointResponse {
         logger.info("포인트 업데이트 id : $id, amount : $amount")
 
-        if (amount < 0) {
+        if (amount <= 0) {
             val message = "충전 금액은 최소 1원 이상 부터 가능합니다. 현재 충전 요청 금액 : $amount"
-            throw IllegalArgumentException(message)
+            throw InvalidAmountRequestException(message)
         }
 
         return PointDto.UserPointResponse(userPointService.chargeUserPoint(id, amount))
@@ -72,7 +73,7 @@ class PointController(
 
         if (amount < 0) {
             val message = "사용 금액은 최소 0원 이상 부터 가능합니다. 현재 사용 요청 금액 : $amount"
-            throw IllegalArgumentException(message)
+            throw InvalidAmountRequestException(message)
         }
 
         return PointDto.UserPointResponse(userPointService.useUserPoint(id, amount))

--- a/src/main/kotlin/io/hhplus/tdd/point/controller/PointDto.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/controller/PointDto.kt
@@ -1,0 +1,38 @@
+package io.hhplus.tdd.point.controller
+
+import io.hhplus.tdd.point.domain.PointHistory
+import io.hhplus.tdd.point.domain.TransactionType
+import io.hhplus.tdd.point.domain.UserPoint
+
+class PointDto {
+
+    // UserPoint 관련 응답값을 책임지는 클래스
+    data class UserPointResponse(
+        val id: Long,
+        val point: Long,
+        val updateMillis: Long,
+    ) {
+        constructor(userPoint: UserPoint) : this(
+            id = userPoint.id,
+            point = userPoint.point,
+            updateMillis = userPoint.updateMillis
+        )
+    }
+
+    // UserPointHistory 관련 응답값을 책임지는 클래스
+    data class UserPointHistoryResponse(
+        val id: Long,
+        val userId: Long,
+        val type: TransactionType,
+        val amount: Long,
+        val timeMillis: Long,
+    ) {
+        constructor(pointHistory: PointHistory) : this(
+            id = pointHistory.id,
+            userId = pointHistory.userId,
+            type = pointHistory.type,
+            amount = pointHistory.amount,
+            timeMillis = pointHistory.timeMillis
+        )
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/PointHistory.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/PointHistory.kt
@@ -1,5 +1,7 @@
 package io.hhplus.tdd.point.domain
 
+import io.hhplus.tdd.exception.InvalidPointAmountException
+
 data class PointHistory(
     val id: Long,
     val userId: Long,
@@ -9,7 +11,7 @@ data class PointHistory(
 ) {
     init {
         if (amount < 0) {
-            throw IllegalArgumentException("포인트는 0 이하일 수 없습니다.")
+            throw InvalidPointAmountException("포인트는 0 이하일 수 없습니다.")
         }
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/UserPoint.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/UserPoint.kt
@@ -1,5 +1,7 @@
 package io.hhplus.tdd.point.domain
 
+import io.hhplus.tdd.exception.InvalidPointAmountException
+
 // entity의 역할
 data class UserPoint(
     val id: Long,
@@ -8,7 +10,7 @@ data class UserPoint(
 ) {
     init {
         if (point < 0) {
-            throw IllegalArgumentException("포인트는 0 이하일 수 없습니다.")
+            throw InvalidPointAmountException("포인트는 0 이하일 수 없습니다.")
         }
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/UserPointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/UserPointService.kt
@@ -28,6 +28,7 @@ class UserPointService(private val userPointRepository: UserPointRepository,
         }
     }
 
+    // 유저 포인트 사용
     fun useUserPoint(id: Long, amount: Long): UserPoint {
         synchronized(this) {
             val userPoint = getUserPointById(id)

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/UserPointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/UserPointService.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point.domain
 
+import io.hhplus.tdd.exception.NotEnoughPointsException
 import io.hhplus.tdd.point.infra.UserPointRepository
 import org.springframework.stereotype.Service
 
@@ -33,7 +34,7 @@ class UserPointService(private val userPointRepository: UserPointRepository,
         synchronized(this) {
             val userPoint = getUserPointById(id)
             if (userPoint.point < amount) {
-                throw IllegalArgumentException("사용하려는 포인트가 가지고있는 포인트보다 많습니다.")
+                throw NotEnoughPointsException("포인트가 부족합니다. 현재 포인트: ${userPoint.point}, 사용하려는 포인트: ${amount}")
             }
             val totalPoint = userPoint.point - amount
             val updatedUserPoint = updateUserPoint(userPoint.id, totalPoint)

--- a/src/test/kotlin/io/hhplus/tdd/point/e2e/PointControllerApiTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/e2e/PointControllerApiTest.kt
@@ -66,8 +66,8 @@ class PointControllerApiTest {
         fun success() {
             // given
             val id: Long = 1
-            val updatePoint: Long = 1000
-            val requestBody = objectMapper.writeValueAsString(updatePoint)
+            val amount: Long = 1000
+            val requestBody = objectMapper.writeValueAsString(amount)
 
             // when then
             mockMvc.perform(
@@ -77,7 +77,7 @@ class PointControllerApiTest {
             )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.id").value(id))
-                .andExpect(jsonPath("$.point").value(updatePoint))
+                .andExpect(jsonPath("$.point").value(amount))
         }
 
         @Test
@@ -85,8 +85,8 @@ class PointControllerApiTest {
         fun failIfPointIsUnderZero() {
             // given
             val id: Long = 2
-            val updatePoint: Long = -1000
-            val requestBody = objectMapper.writeValueAsString(updatePoint)
+            val amount: Long = -1000
+            val requestBody = objectMapper.writeValueAsString(amount)
 
             // when then
             mockMvc.perform(
@@ -95,6 +95,7 @@ class PointControllerApiTest {
                     .content(requestBody)
             )
                 .andExpect(status().is4xxClientError)
+                .andExpect(jsonPath("$.message").value("충전 금액은 최소 1원 이상 부터 가능합니다. 현재 충전 요청 금액 : $amount"))
         }
     }
 
@@ -131,6 +132,7 @@ class PointControllerApiTest {
                     .content(requestBody)
             )
                 .andExpect(status().is4xxClientError)
+                .andExpect(jsonPath("$.message").value("사용 금액은 최소 0원 이상 부터 가능합니다. 현재 사용 요청 금액 : $amount"))
         }
 
         @Test
@@ -146,6 +148,7 @@ class PointControllerApiTest {
                     .content(requestBody)
             )
                 .andExpect(status().is4xxClientError)
+                .andExpect(jsonPath("$.message").value("포인트가 부족합니다. 현재 포인트: 0, 사용하려는 포인트: ${amount}"))
         }
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/unit/domain/PointHistoryTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/unit/domain/PointHistoryTest.kt
@@ -1,0 +1,51 @@
+package io.hhplus.tdd.point.unit.domain
+
+import io.hhplus.tdd.exception.InvalidPointAmountException
+import io.hhplus.tdd.point.domain.PointHistory
+import io.hhplus.tdd.point.domain.TransactionType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class PointHistoryTest {
+
+    @Test
+    fun `포인트 히스토리 객체 생성 (정상)`() {
+        //given
+        val id = 1L
+        val userId = 1L
+        val type: TransactionType =  TransactionType.CHARGE
+        val amount = 1000L
+        val timeMillis = System.currentTimeMillis()
+
+        //when
+        val pointHistory = PointHistory(id = id, userId = userId, type = type, amount = amount, timeMillis = timeMillis)
+
+        //then
+        assertNotNull(pointHistory)
+        assertEquals(id, pointHistory.id)
+        assertEquals(userId, pointHistory.userId)
+        assertEquals(type, pointHistory.type)
+        assertEquals(amount, pointHistory.amount)
+        assertEquals(timeMillis, pointHistory.timeMillis)
+    }
+
+    @Test
+    fun `포인트 히스토리 객체 생성 (amount )`() {
+        //given
+        val id = 1L
+        val userId = 1L
+        val type: TransactionType =  TransactionType.CHARGE
+        val amount = -1000L
+        val timeMillis = System.currentTimeMillis()
+
+        //when
+        val exception = assertThrows<InvalidPointAmountException> {
+            PointHistory(id = id, userId = userId, type = type, amount = amount, timeMillis = timeMillis)
+        }
+
+        assertEquals("포인트는 0 이하일 수 없습니다.", exception.message)
+    }
+}
+

--- a/src/test/kotlin/io/hhplus/tdd/point/unit/domain/UserPointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/unit/domain/UserPointServiceTest.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point.unit.domain
 
+import io.hhplus.tdd.exception.NotEnoughPointsException
 import io.hhplus.tdd.point.domain.PointHistoryService
 import io.hhplus.tdd.point.domain.UserPoint
 import io.hhplus.tdd.point.domain.UserPointService
@@ -106,13 +107,13 @@ class UserPointServiceTest {
             given(mockUserPointRepository.findById(id)).willReturn(expectedUserPoint)
 
             //when
-            val exception = assertThrows<IllegalArgumentException>{
+            val exception = assertThrows<NotEnoughPointsException>{
                 userPointService.useUserPoint(id, amount)
             }
 
             //then
             then(mockUserPointRepository).should().findById(id)
-            assertEquals("사용하려는 포인트가 가지고있는 포인트보다 많습니다.", exception.message)
+            assertEquals("포인트가 부족합니다. 현재 포인트: ${point}, 사용하려는 포인트: ${amount}", exception.message)
 
         }
     }

--- a/src/test/kotlin/io/hhplus/tdd/point/unit/domain/UserPointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/unit/domain/UserPointServiceTest.kt
@@ -1,7 +1,9 @@
 package io.hhplus.tdd.point.unit.domain
 
 import io.hhplus.tdd.exception.NotEnoughPointsException
+import io.hhplus.tdd.point.domain.PointHistory
 import io.hhplus.tdd.point.domain.PointHistoryService
+import io.hhplus.tdd.point.domain.TransactionType
 import io.hhplus.tdd.point.domain.UserPoint
 import io.hhplus.tdd.point.domain.UserPointService
 import io.hhplus.tdd.point.infra.UserPointRepository
@@ -56,8 +58,12 @@ class UserPointServiceTest {
             val expectedFindUserPoint = UserPoint(id = 1, point = 100, updateMillis = 1000) //기대 객체 생성
             val amount: Long = 50
             val expectedSaveUserPoint = UserPoint(id = 1, point = expectedFindUserPoint.point + amount, updateMillis = 1000) //기대 객체 생성
+            val expectedSavePointHistory = PointHistory(1L, 1L, TransactionType.USE, amount, expectedSaveUserPoint.updateMillis)
+
             given(mockUserPointRepository.findById(expectedFindUserPoint.id)).willReturn(expectedFindUserPoint) // mockUserPointRepository의 findById 함수 호출 시 기대객체로 반환
             given(mockUserPointRepository.save(expectedSaveUserPoint.id, expectedSaveUserPoint.point)).willReturn(expectedSaveUserPoint) // mockUserPointRepository의 save 함수 호출 시 기대객체로 반환
+            given(pointHistoryService.save(expectedSaveUserPoint.id, amount, TransactionType.CHARGE, expectedSaveUserPoint.updateMillis))
+                .willReturn(expectedSavePointHistory)
 
             // when
             val userPoint = userPointService.chargeUserPoint(expectedFindUserPoint.id, amount)
@@ -65,6 +71,7 @@ class UserPointServiceTest {
             // then
             then(mockUserPointRepository).should().findById(expectedFindUserPoint.id)
             then(mockUserPointRepository).should().save(expectedSaveUserPoint.id, expectedSaveUserPoint.point)
+            then(pointHistoryService).should().save(expectedSaveUserPoint.id, amount, TransactionType.CHARGE, expectedSaveUserPoint.updateMillis)
             assertNotNull(userPoint)
             assertEquals(expectedSaveUserPoint, userPoint)
         }
@@ -82,10 +89,13 @@ class UserPointServiceTest {
             val totalPoint = point - amount
 
             val expectedFindUserPoint = UserPoint(id = id, point = point, updateMillis = 1000)
-            given(mockUserPointRepository.findById(id)).willReturn(expectedFindUserPoint)
-
             val expectedSaveUserPoint = UserPoint(id = id, point = totalPoint, updateMillis = 1000)
+            val expectedSavePointHistory = PointHistory(1L, id, TransactionType.USE, amount, expectedSaveUserPoint.updateMillis)
+
+            given(mockUserPointRepository.findById(id)).willReturn(expectedFindUserPoint)
             given(mockUserPointRepository.save(id, totalPoint)).willReturn(expectedSaveUserPoint)
+            given(pointHistoryService.save(expectedSaveUserPoint.id, amount, TransactionType.USE, expectedSaveUserPoint.updateMillis))
+                .willReturn(expectedSavePointHistory)
 
             //when
             val result = userPointService.useUserPoint(id, amount)
@@ -93,6 +103,7 @@ class UserPointServiceTest {
             //then
             then(mockUserPointRepository).should().findById(id)
             then(mockUserPointRepository).should().save(id, totalPoint)
+            then(pointHistoryService).should().save(expectedSaveUserPoint.id, amount, TransactionType.USE, expectedSaveUserPoint.updateMillis)
             assertNotNull(result)
             assertEquals(expectedSaveUserPoint, result)
         }

--- a/src/test/kotlin/io/hhplus/tdd/point/unit/domain/UserPointTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/unit/domain/UserPointTest.kt
@@ -1,0 +1,42 @@
+package io.hhplus.tdd.point.unit.domain
+
+import io.hhplus.tdd.exception.InvalidPointAmountException
+import io.hhplus.tdd.point.domain.UserPoint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class UserPointTest {
+    @Test
+    fun `유저 포인트 객체 생성 (정상)`() {
+        //given
+        val id = 1L
+        val point = 1000L
+        val updateMillis = System.currentTimeMillis()
+
+        //when
+        val userPoint = UserPoint(id = id, point = point, updateMillis = updateMillis)
+
+        //then
+        assertNotNull(userPoint)
+        assertEquals(id, userPoint.id)
+        assertEquals(point, userPoint.point)
+        assertEquals(updateMillis, userPoint.updateMillis)
+    }
+
+    @Test
+    fun `유저 포인트 객체 생성 (포인트 음수)`() {
+        //given
+        val id = 1L
+        val point = -1000L
+        val updateMillis = System.currentTimeMillis()
+
+        //when & then
+        val exception = assertThrows<InvalidPointAmountException> {
+            UserPoint(id = id, point = point, updateMillis = updateMillis)
+        }
+
+        assertEquals("포인트는 0 이하일 수 없습니다.", exception.message)
+    }
+}


### PR DESCRIPTION
### 구현 내용
 - 응답값 DTO 변경 (UserPoint -> PointDto.UserPointResponse, UserPointHistory -> PointDto.UserPointHistoryResponse)
 - CustomException 추가 (기존 IllegalArgumentException에서 변경)
 - 누락된 테스트코드 추가 (기존 코드를 변경하였지만, 테스트코드가 통과되는경우를 발견하여 해당 케이스 추가)

### 리뷰 포인트
1. 프리젠테이션 계층을 분리하기 위해 DTO로 작성하였습니다. UserPoint와 UserPointHistory도 Entity와 Domain으로 분리하려한다면 기존에 있는 UserPoint가 Entity역할, 새로 만든 객체(이름 고민...)가 Domain역할을 해야하는것이 맞을까요?? 기존 UserPoint객체가 UserPointTable과 연관관계가 있어 이렇게 생각했습니다.
2. CustomException을 추가하였는데, TDD 단계에서 이미 만들면서 작업을 했어야 할까요??
3. Controller와 Domain의 Custom 에러를 분리 하였습니다.